### PR TITLE
VndError exception

### DIFF
--- a/src/Annotation/VndError.php
+++ b/src/Annotation/VndError.php
@@ -1,0 +1,51 @@
+<?php
+/**
+ * This file is part of the Ray.WebFormModule package
+ *
+ * @license http://opensource.org/licenses/MIT MIT
+ */
+namespace Ray\WebFormModule\Annotation;
+
+/**
+ * @Annotation
+ * @Target("METHOD")
+ */
+final class VndError
+{
+    /**
+     * @var string
+     *
+     * REQUIRED
+     */
+    public $message;
+
+    /**
+     * @var array
+     *
+     * REQUIRED
+     */
+    public $href;
+
+    /**
+     * @var string
+     *
+     * OPTIONAL
+     */
+    public $logref;
+
+    /**
+     * @var string
+     *
+     * OPTIONAL
+     *
+     * help
+     * @see http://www.w3.org/TR/html5/links.html#link-type-help
+     *
+     * about
+     * @see http://tools.ietf.org/html/rfc6903#section-2
+     *
+     * describes
+     * @see http://tools.ietf.org/html/rfc6892
+     */
+    public $path;
+}

--- a/src/AntiCsrf.php
+++ b/src/AntiCsrf.php
@@ -46,7 +46,8 @@ final class AntiCsrf implements AntiCsrfInterface
             $data[self::TOKEN_KEY] = $_POST[self::TOKEN_KEY];
         }
 
-        return isset($data[self::TOKEN_KEY]) && $data[self::TOKEN_KEY] == $this->getToken();    }
+        return isset($data[self::TOKEN_KEY]) && $data[self::TOKEN_KEY] == $this->getToken();
+    }
 
     private function getToken()
     {

--- a/src/AntiCsrf.php
+++ b/src/AntiCsrf.php
@@ -32,13 +32,16 @@ final class AntiCsrf implements AntiCsrfInterface
                  ->setAttribs(['value' => $this->getToken()]);
     }
 
-    /** 
+    /**
      * @param array $data
      *
      * @return bool
      */
     public function isValid(array $data)
     {
+        if (PHP_SAPI === 'cli') {
+            return true;
+        }
         if (isset($_POST[self::TOKEN_KEY])) {
             $data[self::TOKEN_KEY] = $_POST[self::TOKEN_KEY];
         }

--- a/src/AuraInputInterceptor.php
+++ b/src/AuraInputInterceptor.php
@@ -23,11 +23,17 @@ class AuraInputInterceptor implements MethodInterceptor
     private $reader;
 
     /**
+     * @var FailureHandlerInterface
+     */
+    private $failureHandler;
+
+    /**
      * @param Reader $reader Annotation reader
      */
-    public function __construct(Reader $reader)
+    public function __construct(Reader $reader, FailureHandlerInterface $handler)
     {
         $this->reader = $reader;
+        $this->failureHandler = $handler;
     }
 
     /**
@@ -46,13 +52,8 @@ class AuraInputInterceptor implements MethodInterceptor
             // validation   success
             return $invocation->proceed();
         }
-        $args = (array) $invocation->getArguments();
-        $object = $invocation->getThis();
-        if (! method_exists($object, $formValidation->onFailure)) {
-            throw new InvalidOnFailureMethod($formValidation->onFailure);
-        }
 
-        return call_user_func_array([$invocation->getThis(), $formValidation->onFailure], $args);
+        return $this->failureHandler->handle($formValidation, $invocation);
     }
 
     /**

--- a/src/AuraInputInterceptor.php
+++ b/src/AuraInputInterceptor.php
@@ -53,7 +53,7 @@ class AuraInputInterceptor implements MethodInterceptor
             return $invocation->proceed();
         }
 
-        return $this->failureHandler->handle($formValidation, $invocation);
+        return $this->failureHandler->handle($formValidation, $invocation, $form);
     }
 
     /**
@@ -77,7 +77,7 @@ class AuraInputInterceptor implements MethodInterceptor
      * @param FormValidation $formValidation
      * @param object         $object
      *
-     * @return mixed
+     * @return AbstractAuraForm
      */
     private function getFormProperty(FormValidation $formValidation, $object)
     {

--- a/src/Exception/FormValidationException.php
+++ b/src/Exception/FormValidationException.php
@@ -1,0 +1,20 @@
+<?php
+/**
+ * This file is part of the Ray.WebFormModule
+ *
+ * @license http://opensource.org/licenses/bsd-license.php BSD
+ */
+namespace Ray\WebFormModule\Exception;
+
+use Ray\WebFormModule\FormValidationError;
+
+class FormValidationException extends \Exception
+{
+    public $error;
+
+    public function __construct($message = '', $code = 0, \Exception $e = null, FormValidationError $error = null)
+    {
+        parent::__construct($message, $code, $e);
+        $this->error = $error;
+    }
+}

--- a/src/FailureHandlerInterface.php
+++ b/src/FailureHandlerInterface.php
@@ -11,5 +11,5 @@ use Ray\WebFormModule\Annotation\FormValidation;
 
 interface FailureHandlerInterface
 {
-    public function handle(FormValidation $formValidation, MethodInvocation $invocation);
+    public function handle(FormValidation $formValidation, MethodInvocation $invocation, AbstractAuraForm $form);
 }

--- a/src/FailureHandlerInterface.php
+++ b/src/FailureHandlerInterface.php
@@ -1,0 +1,15 @@
+<?php
+/**
+ * This file is part of the Ray.WebFormModule package
+ *
+ * @license http://opensource.org/licenses/MIT MIT
+ */
+namespace Ray\WebFormModule;
+
+use Ray\Aop\MethodInvocation;
+use Ray\WebFormModule\Annotation\FormValidation;
+
+interface FailureHandlerInterface
+{
+    public function handle(FormValidation $formValidation, MethodInvocation $invocation);
+}

--- a/src/FormValidationError.php
+++ b/src/FormValidationError.php
@@ -8,18 +8,37 @@ namespace Ray\WebFormModule;
 
 class FormValidationError
 {
+    /**
+     * @var int
+     */
     public $total;
 
+    /**
+     * @var array
+     */
     public $messages = [];
 
-    public function __construct(array $messages)
+    /**
+     * @var
+     */
+    public $path;
+
+
+    public function __construct($path, array $messages)
     {
+        $this->path = $path;
         $this->total = count($messages);
         $this->messages = $messages;
     }
 
     public function __toString()
     {
-        return json_encode($this->messages);
+        $vndError = [
+            'path' => $this->path,
+            'message' => 'Validation failed',
+            'validation_messages' => [$this->messages]
+        ];
+
+        return json_encode($vndError, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES);
     }
 }

--- a/src/FormValidationError.php
+++ b/src/FormValidationError.php
@@ -1,0 +1,25 @@
+<?php
+/**
+ * This file is part of the Ray.WebFormModule package
+ *
+ * @license http://opensource.org/licenses/MIT MIT
+ */
+namespace Ray\WebFormModule;
+
+class FormValidationError
+{
+    public $total;
+
+    public $messages = [];
+
+    public function __construct(array $messages)
+    {
+        $this->total = count($messages);
+        $this->messages = $messages;
+    }
+
+    public function __toString()
+    {
+        return json_encode($this->messages);
+    }
+}

--- a/src/FormValidationError.php
+++ b/src/FormValidationError.php
@@ -9,36 +9,17 @@ namespace Ray\WebFormModule;
 class FormValidationError
 {
     /**
-     * @var int
-     */
-    public $total;
-
-    /**
      * @var array
      */
-    public $messages = [];
+    private $value;
 
-    /**
-     * @var
-     */
-    public $path;
-
-
-    public function __construct($path, array $messages)
+    public function __construct(array $value)
     {
-        $this->path = $path;
-        $this->total = count($messages);
-        $this->messages = $messages;
+        $this->value = $value;
     }
 
     public function __toString()
     {
-        $vndError = [
-            'path' => $this->path,
-            'message' => 'Validation failed',
-            'validation_messages' => [$this->messages]
-        ];
-
-        return json_encode($vndError, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES);
+        return json_encode($this->value, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES);
     }
 }

--- a/src/FormVndErrorModule.php
+++ b/src/FormVndErrorModule.php
@@ -1,0 +1,20 @@
+<?php
+/**
+ * This file is part of the Ray.WebFormModule package
+ *
+ * @license http://opensource.org/licenses/MIT MIT
+ */
+namespace Ray\WebFormModule;
+
+use Ray\Di\AbstractModule;
+
+class FormVndErrorModule extends AbstractModule
+{
+    /**
+     * {@inheritdoc}
+     */
+    protected function configure()
+    {
+        $this->bind(FailureHandlerInterface::class)->to(VndErrorHandler::class);
+    }
+}

--- a/src/OnFailureMethodHandler.php
+++ b/src/OnFailureMethodHandler.php
@@ -17,6 +17,7 @@ final class OnFailureMethodHandler implements FailureHandlerInterface
      */
     public function handle(FormValidation $formValidation, MethodInvocation $invocation, AbstractAuraForm $form)
     {
+        unset($form);
         $args = (array) $invocation->getArguments();
         $object = $invocation->getThis();
         if (! method_exists($object, $formValidation->onFailure)) {

--- a/src/OnFailureMethodHandler.php
+++ b/src/OnFailureMethodHandler.php
@@ -15,7 +15,7 @@ final class OnFailureMethodHandler implements FailureHandlerInterface
     /**
      * {@inheritdoc}
      */
-    public function handle(FormValidation $formValidation, MethodInvocation $invocation)
+    public function handle(FormValidation $formValidation, MethodInvocation $invocation, AbstractAuraForm $form)
     {
         $args = (array) $invocation->getArguments();
         $object = $invocation->getThis();

--- a/src/OnFailureMethodHandler.php
+++ b/src/OnFailureMethodHandler.php
@@ -1,0 +1,28 @@
+<?php
+/**
+ * This file is part of the Ray.WebFormModule package
+ *
+ * @license http://opensource.org/licenses/MIT MIT
+ */
+namespace Ray\WebFormModule;
+
+use Ray\Aop\MethodInvocation;
+use Ray\WebFormModule\Annotation\FormValidation;
+use Ray\WebFormModule\Exception\InvalidOnFailureMethod;
+
+final class OnFailureMethodHandler implements FailureHandlerInterface
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function handle(FormValidation $formValidation, MethodInvocation $invocation)
+    {
+        $args = (array) $invocation->getArguments();
+        $object = $invocation->getThis();
+        if (! method_exists($object, $formValidation->onFailure)) {
+            throw new InvalidOnFailureMethod($formValidation->onFailure);
+        }
+
+        return call_user_func_array([$invocation->getThis(), $formValidation->onFailure], $args);
+    }
+}

--- a/src/VndErrorHandler.php
+++ b/src/VndErrorHandler.php
@@ -6,22 +6,60 @@
  */
 namespace Ray\WebFormModule;
 
+use Doctrine\Common\Annotations\Reader;
 use Ray\Aop\MethodInvocation;
 use Ray\WebFormModule\Annotation\FormValidation;
+use Ray\WebFormModule\Annotation\VndError;
 use Ray\WebFormModule\Exception\FormValidationException;
 
 final class VndErrorHandler implements FailureHandlerInterface
 {
     /**
+     * @var Reader
+     */
+    private $reader;
+
+    public function __construct(Reader $reader)
+    {
+        $this->reader = $reader;
+    }
+
+    /**
      * {@inheritdoc}
      */
     public function handle(FormValidation $formValidation, MethodInvocation $invocation, AbstractAuraForm $form)
     {
-        $messages = $form->getMessages();
-        $path = isset($_SERVER['PATH_INFO']) ? $_SERVER['PATH_INFO'] : '/';
-        $error =  new FormValidationError($path, $messages);
+        $vndError = $this->reader->getMethodAnnotation($invocation->getMethod(), VndError::class);
+        $error =  new FormValidationError($this->makeVndError($form, $vndError));
         $e = new FormValidationException('Validation failed.', 400, null, $error);
 
         throw $e;
+    }
+
+    private function makeVndError(AbstractAuraForm $form, VndError $vndError = null)
+    {
+
+        $body = ['message' => 'Validation failed'];
+        $body['path'] = isset($_SERVER['PATH_INFO']) ? $_SERVER['PATH_INFO'] : '';
+        $body['validation_messages'] = $form->getMessages();
+        $body = $vndError ? $this->optionalAttribute($vndError) + $body : $body;
+
+        return $body;
+    }
+
+    private function optionalAttribute(VndError $vndError)
+    {
+        $body = [];
+        if ($vndError->message) {
+            $body['message'] = $vndError->message;
+        }
+        if ($vndError->path) {
+            $body['path'] = $vndError->path;
+        }
+        if ($vndError->logref) {
+            $body['logref'] = $vndError->logref;
+        }
+
+        return $body;
     }
 }

--- a/src/VndErrorHandler.php
+++ b/src/VndErrorHandler.php
@@ -1,0 +1,26 @@
+<?php
+/**
+ * This file is part of the Ray.WebFormModule package
+ *
+ * @license http://opensource.org/licenses/MIT MIT
+ */
+namespace Ray\WebFormModule;
+
+use Ray\Aop\MethodInvocation;
+use Ray\WebFormModule\Annotation\FormValidation;
+use Ray\WebFormModule\Exception\FormValidationException;
+
+final class VndErrorHandler implements FailureHandlerInterface
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function handle(FormValidation $formValidation, MethodInvocation $invocation, AbstractAuraForm $form)
+    {
+        $messages = $form->getMessages();
+        $error =  new FormValidationError($messages);
+        $e = new FormValidationException('Validation failed.', 400, null, $error);
+
+        throw $e;
+    }
+}

--- a/src/VndErrorHandler.php
+++ b/src/VndErrorHandler.php
@@ -18,7 +18,8 @@ final class VndErrorHandler implements FailureHandlerInterface
     public function handle(FormValidation $formValidation, MethodInvocation $invocation, AbstractAuraForm $form)
     {
         $messages = $form->getMessages();
-        $error =  new FormValidationError($messages);
+        $path = isset($_SERVER['PATH_INFO']) ? $_SERVER['PATH_INFO'] : '/';
+        $error =  new FormValidationError($path, $messages);
         $e = new FormValidationException('Validation failed.', 400, null, $error);
 
         throw $e;

--- a/src/VndErrorHandler.php
+++ b/src/VndErrorHandler.php
@@ -29,6 +29,7 @@ final class VndErrorHandler implements FailureHandlerInterface
      */
     public function handle(FormValidation $formValidation, MethodInvocation $invocation, AbstractAuraForm $form)
     {
+        unset($formValidation);
         $vndError = $this->reader->getMethodAnnotation($invocation->getMethod(), VndError::class);
         $error =  new FormValidationError($this->makeVndError($form, $vndError));
         $e = new FormValidationException('Validation failed.', 400, null, $error);

--- a/src/WebFormModule.php
+++ b/src/WebFormModule.php
@@ -31,6 +31,7 @@ class WebFormModule extends AbstractModule
         $this->bind(FilterInterface::class)->to(Filter::class);
         $this->bind(HelperLocatorFactory::class);
         $this->bind(AntiCsrfInterface::class)->to(AntiCsrf::class)->in(Scope::SINGLETON);
+        $this->bind(FailureHandlerInterface::class)->to(OnFailureMethodHandler::class);
         $this->bindInterceptor(
             $this->matcher->any(),
             $this->matcher->annotatedWith(FormValidation::class),

--- a/tests/AntiCsrfTest.php
+++ b/tests/AntiCsrfTest.php
@@ -53,11 +53,6 @@ class AntiCsrfTest extends \PHPUnit_Framework_TestCase
         $this->assertNull($result);
     }
 
-    public function testIsValidFailed()
-    {
-        $this->assertFalse($this->antiCsrf->isValid([]));
-    }
-
     public function testIsValid()
     {
         $data = ['__csrf_token' => AntiCsrf::TEST_TOKEN];

--- a/tests/AuraInputInterceptorTest.php
+++ b/tests/AuraInputInterceptorTest.php
@@ -34,7 +34,7 @@ class AuraInputInterceptorTest extends \PHPUnit_Framework_TestCase
             new \ReflectionMethod($object, $method),
             new Arguments([]),
             [
-                new AuraInputInterceptor(new AnnotationReader)
+                new AuraInputInterceptor(new AnnotationReader, new OnFailureMethodHandler)
             ]
         );
     }
@@ -57,7 +57,7 @@ class AuraInputInterceptorTest extends \PHPUnit_Framework_TestCase
             new \ReflectionMethod($controller, 'createAction'),
             new Arguments([]),
             [
-                new AuraInputInterceptor(new AnnotationReader)
+                new AuraInputInterceptor(new AnnotationReader, new OnFailureMethodHandler)
             ]
         );
         $invocation->proceed();
@@ -113,7 +113,7 @@ class AuraInputInterceptorTest extends \PHPUnit_Framework_TestCase
             new \ReflectionMethod($object, 'createAction'),
             new Arguments([]),
             [
-                new AuraInputInterceptor(new AnnotationReader)
+                new AuraInputInterceptor(new AnnotationReader, new OnFailureMethodHandler)
             ]
         );
         $invocation->proceed();

--- a/tests/AuraInputInterceptorTest.php
+++ b/tests/AuraInputInterceptorTest.php
@@ -124,21 +124,19 @@ class AuraInputInterceptorTest extends \PHPUnit_Framework_TestCase
     public function testProceedWithVndErrorHandler()
     {
         try {
-            $invocation = $this->getMethodInvocation('createAction', [], new VndErrorHandler);
+            $invocation = $this->getMethodInvocation('createAction', [], new VndErrorHandler(new AnnotationReader));
             $invocation->proceed();
         } catch (FormValidationException $e) {
             $this->assertInstanceOf(FormValidationError::class, $e->error);
             $json = (string) $e->error;
             $this->assertSame('{
-    "path": "/",
     "message": "Validation failed",
-    "validation_messages": [
-        {
-            "name": [
-                "Name must be alphabetic only."
-            ]
-        }
-    ]
+    "path": "",
+    "validation_messages": {
+        "name": [
+            "Name must be alphabetic only."
+        ]
+    }
 }', $json);
         }
     }

--- a/tests/AuraInputInterceptorTest.php
+++ b/tests/AuraInputInterceptorTest.php
@@ -8,6 +8,7 @@ use Aura\Input\Filter;
 use Doctrine\Common\Annotations\AnnotationReader;
 use Ray\Aop\Arguments;
 use Ray\Aop\ReflectiveMethodInvocation;
+use Ray\WebFormModule\Exception\FormValidationException;
 use Ray\WebFormModule\Exception\InvalidFormPropertyException;
 use Ray\WebFormModule\Exception\InvalidOnFailureMethod;
 
@@ -26,15 +27,16 @@ class AuraInputInterceptorTest extends \PHPUnit_Framework_TestCase
     /**
      * @param $method
      */
-    public function getMethodInvocation($method, array $submit)
+    public function getMethodInvocation($method, array $submit, FailureHandlerInterface $handler = null)
     {
+        $handler = $handler ?: new OnFailureMethodHandler;
         $object = $this->getController($submit);
         return new ReflectiveMethodInvocation(
             $object,
             new \ReflectionMethod($object, $method),
             new Arguments([]),
             [
-                new AuraInputInterceptor(new AnnotationReader, new OnFailureMethodHandler)
+                new AuraInputInterceptor(new AnnotationReader, $handler)
             ]
         );
     }
@@ -117,5 +119,15 @@ class AuraInputInterceptorTest extends \PHPUnit_Framework_TestCase
             ]
         );
         $invocation->proceed();
+    }
+
+    public function testProceedWithVndErrorHandler()
+    {
+        try {
+            $invocation = $this->getMethodInvocation('createAction', [], new VndErrorHandler);
+            $invocation->proceed();
+        } catch (FormValidationException $e) {
+            $this->assertInstanceOf(FormValidationError::class, $e->error);
+        }
     }
 }

--- a/tests/AuraInputInterceptorTest.php
+++ b/tests/AuraInputInterceptorTest.php
@@ -128,6 +128,18 @@ class AuraInputInterceptorTest extends \PHPUnit_Framework_TestCase
             $invocation->proceed();
         } catch (FormValidationException $e) {
             $this->assertInstanceOf(FormValidationError::class, $e->error);
+            $json = (string) $e->error;
+            $this->assertSame('{
+    "path": "/",
+    "message": "Validation failed",
+    "validation_messages": [
+        {
+            "name": [
+                "Name must be alphabetic only."
+            ]
+        }
+    ]
+}', $json);
         }
     }
 }

--- a/tests/Fake/FakeControllerVndError.php
+++ b/tests/Fake/FakeControllerVndError.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Ray\WebFormModule;
+
+use Ray\Di\Di\Inject;
+use Ray\Di\Di\Named;
+use Ray\WebFormModule\Annotation\FormValidation;
+use Ray\WebFormModule\Annotation\VndError;
+
+class FakeControllerVndError
+{
+    /**
+     * @var FormInterface
+     */
+    protected $form1;
+
+    /**
+     * @Inject
+     * @Named("contact_form")
+     */
+    public function setForm(FormInterface $form)
+    {
+        $this->form1 = $form;
+    }
+
+    /**
+     * @FormValidation(form="form1", onFailure="badRequestAction")
+     * @VndError(message="foo validation failed", logref="a1000", path="/path/to/error", href={"_self"="/path/to/error", "help"="/path/to/help"})
+     */
+    public function createAction()
+    {
+    }
+}

--- a/tests/Fake/FakeControllerVndError.php
+++ b/tests/Fake/FakeControllerVndError.php
@@ -25,7 +25,11 @@ class FakeControllerVndError
 
     /**
      * @FormValidation(form="form1", onFailure="badRequestAction")
-     * @VndError(message="foo validation failed", logref="a1000", path="/path/to/error", href={"_self"="/path/to/error", "help"="/path/to/help"})
+     * @VndError(
+     *   message="foo validation failed",
+     *   logref="a1000", path="/path/to/error",
+     *   href={"_self"="/path/to/error", "help"="/path/to/help"}
+     * )
      */
     public function createAction()
     {

--- a/tests/Fake/FakeVndErrorModule.php
+++ b/tests/Fake/FakeVndErrorModule.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Ray\WebFormModule;
+
+use Ray\Di\AbstractModule;
+
+class FakeVndErrorModule extends AbstractModule
+{
+    protected function configure()
+    {
+        $this->install(new FormVndErrorModule);
+        $this->install(new FakeModule);
+    }
+}

--- a/tests/VndErrorHandlerTest.php
+++ b/tests/VndErrorHandlerTest.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace Ray\WebFormModule;
+
+use Ray\Di\Injector;
+use Ray\WebFormModule\Exception\FormValidationException;
+
+class VndErrorHandlerTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @var FakeController
+     */
+    private $controller;
+
+    public function setUp()
+    {
+        parent::setUp();
+        $this->controller = (new Injector(new FakeVndErrorModule))->getInstance(FakeController::class);
+    }
+
+    public function testFormValidationException()
+    {
+        $this->setExpectedException(FormValidationException::class);
+        $this->controller->createAction();
+    }
+
+    public function testFormValidationExceptionError()
+    {
+        try {
+            $this->controller->createAction();
+        } catch(FormValidationException $e) {
+            $vndError = (string) $e->error;
+            $this->assertSame('{
+    "path": "/",
+    "message": "Validation failed",
+    "validation_messages": [
+        {
+            "name": [
+                "Name must be alphabetic only."
+            ]
+        }
+    ]
+}', $vndError);
+        }
+    }
+}

--- a/tests/VndErrorHandlerTest.php
+++ b/tests/VndErrorHandlerTest.php
@@ -31,16 +31,36 @@ class VndErrorHandlerTest extends \PHPUnit_Framework_TestCase
         } catch(FormValidationException $e) {
             $vndError = (string) $e->error;
             $this->assertSame('{
-    "path": "/",
     "message": "Validation failed",
-    "validation_messages": [
-        {
-            "name": [
-                "Name must be alphabetic only."
-            ]
-        }
-    ]
+    "path": "",
+    "validation_messages": {
+        "name": [
+            "Name must be alphabetic only."
+        ]
+    }
 }', $vndError);
         }
     }
+
+    public function testVndErrorAnnotation()
+    {
+        /** @var $controller FakeControllerVndError */
+        $controller = (new Injector(new FakeVndErrorModule))->getInstance(FakeControllerVndError::class);
+        try {
+            $controller->createAction();
+        } catch(FormValidationException $e) {
+            $vndError = (string) $e->error;
+            $this->assertSame('{
+    "message": "foo validation failed",
+    "path": "/path/to/error",
+    "logref": "a1000",
+    "validation_messages": {
+        "name": [
+            "Name must be alphabetic only."
+        ]
+    }
+}', $vndError);
+        }
+    }
+
 }


### PR DESCRIPTION
A `Ray\WebFormModule\Exception\FormValidationException`  exception thrown when form validation failed. We need `FormVndErrorModule` for this. This is useful for non-html API application.

``` php
use  Ray\WebFormModule\FormVndErrorModule;

class MyModule extends AbstractModule
{
    protected function configure()
    {
        $this->install(new FormVndErrorModule);
    }
```
