### PR TITLE
On failure method suffix

### DIFF
--- a/src/OnFailureMethodHandler.php
+++ b/src/OnFailureMethodHandler.php
@@ -13,6 +13,8 @@ use Ray\WebFormModule\Exception\InvalidOnFailureMethod;
 
 final class OnFailureMethodHandler implements FailureHandlerInterface
 {
+    const FAILURE_SUFFIX = 'ValidationFailed';
+
     /**
      * {@inheritdoc}
      */
@@ -21,10 +23,14 @@ final class OnFailureMethodHandler implements FailureHandlerInterface
         unset($form);
         $args = (array) $invocation->getArguments();
         $object = $invocation->getThis();
-        if (! $formValidation instanceof FormValidation || ! method_exists($object, $formValidation->onFailure)) {
+        if (! $formValidation instanceof FormValidation) {
+            throw new InvalidOnFailureMethod(get_class($invocation->getThis()));
+        }
+        $onFailureMethod = $formValidation->onFailure ?: $invocation->getMethod()->getName() . self::FAILURE_SUFFIX;
+        if (! $formValidation instanceof FormValidation || ! method_exists($object, $onFailureMethod)) {
             throw new InvalidOnFailureMethod(get_class($invocation->getThis()));
         }
 
-        return call_user_func_array([$invocation->getThis(), $formValidation->onFailure], $args);
+        return call_user_func_array([$invocation->getThis(), $onFailureMethod], $args);
     }
 }

--- a/tests/Fake/FakeController.php
+++ b/tests/Fake/FakeController.php
@@ -11,7 +11,7 @@ class FakeController
     /**
      * @var FormInterface
      */
-    protected $form1;
+    protected $form;
 
     /**
      * @Inject
@@ -19,18 +19,20 @@ class FakeController
      */
     public function setForm(FormInterface $form)
     {
-        $this->form1 = $form;
+        $this->form = $form;
     }
 
     /**
-     * @FormValidation(form="form1", onFailure="badRequestAction")
+     * @FormValidation
+     * 
+     * = is same as @ FormValidation(form="form", onFailure="createActionValidationFailed")
      */
     public function createAction($name)
     {
         return '201';
     }
 
-    public function badRequestAction()
+    public function createActionValidationFailed()
     {
         return '400';
     }

--- a/tests/Fake/FakeController.php
+++ b/tests/Fake/FakeController.php
@@ -24,7 +24,7 @@ class FakeController
 
     /**
      * @FormValidation
-     * 
+     *
      * = is same as @ FormValidation(form="form", onFailure="createActionValidationFailed")
      */
     public function createAction($name)

--- a/tests/Fake/FakeControllerVndError.php
+++ b/tests/Fake/FakeControllerVndError.php
@@ -4,7 +4,7 @@ namespace Ray\WebFormModule;
 
 use Ray\Di\Di\Inject;
 use Ray\Di\Di\Named;
-use Ray\WebFormModule\Annotation\FormValidation;
+use Ray\WebFormModule\Annotation\InputValidation;
 use Ray\WebFormModule\Annotation\VndError;
 
 class FakeControllerVndError
@@ -24,10 +24,11 @@ class FakeControllerVndError
     }
 
     /**
-     * @FormValidation(form="form1", onFailure="badRequestAction")
+     * @InputValidation(form="form1")
      * @VndError(
      *   message="foo validation failed",
-     *   logref="a1000", path="/path/to/error",
+     *   logref="a1000",
+     *   path="/path/to/error",
      *   href={"_self"="/path/to/error", "help"="/path/to/help"}
      * )
      */

--- a/tests/Fake/FakeInputValidationController.php
+++ b/tests/Fake/FakeInputValidationController.php
@@ -11,7 +11,7 @@ class FakeInputValidationController
     /**
      * @var FormInterface
      */
-    protected $form1;
+    protected $form;
 
     /**
      * @Inject
@@ -19,11 +19,11 @@ class FakeInputValidationController
      */
     public function setForm(FormInterface $form)
     {
-        $this->form1 = $form;
+        $this->form  = $form;
     }
 
     /**
-     * @InputValidation(form="form1")
+     * @InputValidation
      */
     public function createAction($name)
     {

--- a/tests/Fake/FakeInvalidController2.php
+++ b/tests/Fake/FakeInvalidController2.php
@@ -9,7 +9,7 @@ class FakeInvalidController2
     private $form = null;
 
     /**
-     * @FormValidation(form="form")
+     * @FormValidation
      */
     public function createAction()
     {

--- a/tests/Fake/FakeInvalidInstanceController.php
+++ b/tests/Fake/FakeInvalidInstanceController.php
@@ -9,7 +9,7 @@ class FakeInvalidInstanceController
     private $form;
 
     /**
-     * @FormValidation(form="form")
+     * @FormValidation
      */
     public function createAction()
     {


### PR DESCRIPTION
`ValidationFailed` is used for validation failed method suffix when `method` property is unset.

``` php
class Foo
{
    /**
     * @FormValidation
     */
    public function createAction($name)
    {
    }

    public function createActionValidationFailed()
    {
        // called when validation failed
    }
```
