### PR TITLE
__toString exception handling

### DIFF
--- a/src/AbstractForm.php
+++ b/src/AbstractForm.php
@@ -14,6 +14,7 @@ use Aura\Input\AntiCsrfInterface;
 use Aura\Input\BuilderInterface;
 use Aura\Input\Fieldset;
 use Ray\WebFormModule\Exception\CsrfViolationException;
+use Ray\WebFormModule\Exception\LogicException;
 
 abstract class AbstractForm extends Fieldset implements FormInterface
 {
@@ -45,6 +46,26 @@ abstract class AbstractForm extends Fieldset implements FormInterface
     {
         $this->filter = clone $this->filter;
         $this->init();
+    }
+
+    /**
+     * Return form markup string
+     *
+     * @return string
+     */
+    public function __toString()
+    {
+        try {
+            if (! $this instanceof ToStringInterface) {
+                throw new LogicException(ToStringInterface::class . ' is not implemented');
+            }
+
+            return $this->toString();
+        } catch (\Exception $e) {
+            trigger_error($e->getMessage() . PHP_EOL . $e->getTraceAsString(), E_USER_ERROR);
+
+            return '';
+        }
     }
 
     /**
@@ -140,9 +161,8 @@ abstract class AbstractForm extends Fieldset implements FormInterface
             throw new CsrfViolationException;
         }
         $this->fill($data);
-        $isValid = $this->filter->apply($data);
 
-        return $isValid;
+        return $this->filter->apply($data);
     }
 
     /**
@@ -152,9 +172,7 @@ abstract class AbstractForm extends Fieldset implements FormInterface
      */
     public function getFailureMessages()
     {
-        $messages = $this->filter->getFailures()->getMessages();
-
-        return $messages;
+        return $this->filter->getFailures()->getMessages();
     }
 
     /**

--- a/src/ToStringInterface.php
+++ b/src/ToStringInterface.php
@@ -1,0 +1,15 @@
+<?php
+/**
+ * This file is part of the Ray.WebFormModule package.
+ *
+ * @license http://opensource.org/licenses/MIT MIT
+ */
+namespace Ray\WebFormModule;
+
+/**
+ * Return form markup string
+ */
+interface ToStringInterface
+{
+    public function toString() : string;
+}

--- a/src/VndErrorHandler.php
+++ b/src/VndErrorHandler.php
@@ -32,9 +32,8 @@ final class VndErrorHandler implements FailureHandlerInterface
         unset($formValidation);
         $vndError = $this->reader->getMethodAnnotation($invocation->getMethod(), VndError::class);
         $error = new FormValidationError($this->makeVndError($form, $vndError));
-        $e = new ValidationException('Validation failed.', 400, null, $error);
 
-        throw $e;
+        throw new ValidationException('Validation failed.', 400, null, $error);
     }
 
     private function makeVndError(AbstractForm $form, VndError $vndError = null)

--- a/tests/AbstractAuraFormTest.php
+++ b/tests/AbstractAuraFormTest.php
@@ -60,4 +60,17 @@ class AbstractAuraFormTest extends \PHPUnit_Framework_TestCase
         $expected = '<input id="name" type="text" name="name" value="@invalid@" />';
         $this->assertContains($expected, $html);
     }
+
+    public function testNotToStringImplemented()
+    {
+        $errNo = $errStr = '';
+        set_error_handler(function (int $no, string $str) use (&$errNo, &$errStr) {
+            $errNo = $no;
+            $errStr = $str;
+        });
+        $form = new FakeErrorForm;
+        (string) $form;
+        $this->assertSame(256, $errNo);
+        restore_error_handler();
+    }
 }

--- a/tests/Fake/FakeErrorForm.php
+++ b/tests/Fake/FakeErrorForm.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Ray\WebFormModule;
+
+class FakeErrorForm extends AbstractForm
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function init()
+    {
+    }
+}

--- a/tests/Fake/FakeNameForm.php
+++ b/tests/Fake/FakeNameForm.php
@@ -4,7 +4,7 @@ namespace Ray\WebFormModule;
 
 use Aura\Html\Helper\Tag;
 
-class FakeNameForm extends AbstractForm
+class FakeNameForm extends AbstractForm implements ToStringInterface
 {
     /**
      * {@inheritdoc}
@@ -41,7 +41,7 @@ class FakeNameForm extends AbstractForm
     /**
      * {@inheritdoc}
      */
-    public function __toString()
+    public function toString() : string
     {
         $form = $this->form([
             'method' => 'post',


### PR DESCRIPTION
User can implement `toStringInterface` instead of using `__toString` method to get markup for the form. It trigger `E_USER_ERROR` instead of fatal error.