### PR TITLE
Introduce WebFormModule and keep AuraInputModule as alias

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,20 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.0.1] - 2026-05-18
+
+### Added
+
+- `Ray\WebFormModule\WebFormModule` — module class whose name matches the
+  package and namespace. Use this in new code.
+
+### Deprecated
+
+- `Ray\WebFormModule\AuraInputModule` is now a thin subclass of
+  `WebFormModule` kept for backwards compatibility. Existing applications
+  that install `new AuraInputModule()` continue to work without changes,
+  but should migrate to `new WebFormModule()`.
+
 ## [1.0.0] - 2026-05-17
 
 ### Changed
@@ -75,5 +89,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 See git history for changes prior to 1.0.0.
 
+[1.0.1]: https://github.com/ray-di/Ray.WebFormModule/compare/1.0.0...1.0.1
 [1.0.0]: https://github.com/ray-di/Ray.WebFormModule/compare/0.6.0...1.0.0
 [0.6.0]: https://github.com/ray-di/Ray.WebFormModule/releases/tag/0.6.0

--- a/README.JA.md
+++ b/README.JA.md
@@ -18,16 +18,19 @@ Ray.WebFormModuleはアスペクト指向でフォームのバリデーション
 
 ```php
 use Ray\Di\AbstractModule;
-use Ray\WebFormModule\AuraInputModule;
+use Ray\WebFormModule\WebFormModule;
 
 class AppModule extends AbstractModule
 {
     protected function configure()
     {
-        $this->install(new AuraInputModule);
+        $this->install(new WebFormModule());
     }
 }
 ```
+
+> 互換性のため `Ray\WebFormModule\AuraInputModule` クラスも `WebFormModule` の薄い
+> サブクラスとして残されています。新規コードでは `WebFormModule` を使ってください。
 ## Usage
 
 ### Form
@@ -201,8 +204,8 @@ class FakeVndErrorModule extends AbstractModule
 {
     protected function configure()
     {
-        $this->install(new AuraInputModule);
-        $this->override(new FormVndErrorModule);
+        $this->install(new WebFormModule());
+        $this->override(new FormVndErrorModule());
     }
 ``` 
 

--- a/README.md
+++ b/README.md
@@ -18,16 +18,20 @@ An aspect oriented web form module powered by [Aura.Input](https://github.com/au
 
 ```php
 use Ray\Di\AbstractModule;
-use Ray\WebFormModule\AuraInputModule;
+use Ray\WebFormModule\WebFormModule;
 
 class AppModule extends AbstractModule
 {
     protected function configure()
     {
-        $this->install(new AuraInputModule);
+        $this->install(new WebFormModule());
     }
 }
 ```
+
+> The legacy `Ray\WebFormModule\AuraInputModule` class is still available as a thin
+> subclass of `WebFormModule` for backwards compatibility. New code should prefer
+> `WebFormModule`.
 ## Usage
 
 ### Form class
@@ -202,8 +206,8 @@ class FakeVndErrorModule extends AbstractModule
 {
     protected function configure()
     {
-        $this->install(new AuraInputModule);
-        $this->override(new FormVndErrorModule);
+        $this->install(new WebFormModule());
+        $this->override(new FormVndErrorModule());
     }
 ``` 
 A `Ray\WebFormModule\Exception\ValidationException` will be thrown.

--- a/docs/demo/1.csrf/MyModule.php
+++ b/docs/demo/1.csrf/MyModule.php
@@ -7,7 +7,7 @@ class MyModule extends AbstractModule
 {
     protected function configure()
     {
-        $this->install(new AuraInputModule);
+        $this->install(new WebFormModule());
         $this->bind(FormInterface::class)->annotatedWith('contact_form')->to(ContactForm::class);
     }
 }

--- a/psalm.xml
+++ b/psalm.xml
@@ -27,5 +27,21 @@
                 <file name="src/AntiCsrf.php" />
             </errorLevel>
         </MoreSpecificImplementedParamType>
+        <!--
+            Psalm misresolves Ray\Di\Bind and Ray\Aop\Pointcut signatures inside
+            Ray\Di\AbstractModule::bindInterceptor() when AbstractModule is reached
+            through a two-level inheritance chain (AuraInputModule -> WebFormModule
+            -> AbstractModule). The vendor code itself is correct.
+        -->
+        <InvalidArgument>
+            <errorLevel type="suppress">
+                <referencedFunction name="Ray\Aop\Pointcut::__construct" />
+            </errorLevel>
+        </InvalidArgument>
+        <TooManyArguments>
+            <errorLevel type="suppress">
+                <referencedFunction name="Ray\Di\Bind::__construct" />
+            </errorLevel>
+        </TooManyArguments>
     </issueHandlers>
 </psalm>

--- a/src/AuraInputModule.php
+++ b/src/AuraInputModule.php
@@ -4,43 +4,13 @@ declare(strict_types=1);
 
 namespace Ray\WebFormModule;
 
-use Aura\Filter\FilterFactory;
-use Aura\Html\HelperLocatorFactory;
-use Aura\Input\AntiCsrfInterface;
-use Aura\Input\Builder;
-use Aura\Input\BuilderInterface;
-use Aura\Input\Filter;
-use Aura\Input\FilterInterface;
-use Ray\AuraSessionModule\AuraSessionModule;
-use Ray\Di\AbstractModule;
-use Ray\Di\Scope;
-use Ray\WebFormModule\Annotation\FormValidation;
-use Ray\WebFormModule\Annotation\InputValidation;
-
-/** @SuppressWarnings(PHPMD.CouplingBetweenObjects) */
-class AuraInputModule extends AbstractModule
+/**
+ * Backwards-compatible alias for {@see WebFormModule}.
+ *
+ * Use {@see WebFormModule} in new code. This class is kept so existing
+ * applications that install `new AuraInputModule()` continue to work
+ * without changes.
+ */
+class AuraInputModule extends WebFormModule
 {
-    /** {@inheritDoc} */
-    protected function configure()
-    {
-        $this->install(new AuraSessionModule());
-        $this->bind(BuilderInterface::class)->to(Builder::class);
-        $this->bind(FilterInterface::class)->to(Filter::class);
-        $this->bind(AntiCsrfInterface::class)->to(AntiCsrf::class)->in(Scope::SINGLETON);
-        $this->bind(FailureHandlerInterface::class)->to(OnFailureMethodHandler::class);
-        $this->bind(FailureHandlerInterface::class)
-            ->annotatedWith('vnd_error')->to(VndErrorHandler::class)->in(Scope::SINGLETON);
-        $this->bind(HelperLocatorFactory::class);
-        $this->bind(FilterFactory::class);
-        $this->bindInterceptor(
-            $this->matcher->any(),
-            $this->matcher->annotatedWith(InputValidation::class),
-            [InputValidationInterceptor::class],
-        );
-        $this->bindInterceptor(
-            $this->matcher->any(),
-            $this->matcher->annotatedWith(FormValidation::class),
-            [AuraInputInterceptor::class],
-        );
-    }
 }

--- a/src/WebFormModule.php
+++ b/src/WebFormModule.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ray\WebFormModule;
+
+use Aura\Filter\FilterFactory;
+use Aura\Html\HelperLocatorFactory;
+use Aura\Input\AntiCsrfInterface;
+use Aura\Input\Builder;
+use Aura\Input\BuilderInterface;
+use Aura\Input\Filter;
+use Aura\Input\FilterInterface;
+use Ray\AuraSessionModule\AuraSessionModule;
+use Ray\Di\AbstractModule;
+use Ray\Di\Scope;
+use Ray\WebFormModule\Annotation\FormValidation;
+use Ray\WebFormModule\Annotation\InputValidation;
+
+/** @SuppressWarnings(PHPMD.CouplingBetweenObjects) */
+class WebFormModule extends AbstractModule
+{
+    /** {@inheritDoc} */
+    protected function configure()
+    {
+        $this->install(new AuraSessionModule());
+        $this->bind(BuilderInterface::class)->to(Builder::class);
+        $this->bind(FilterInterface::class)->to(Filter::class);
+        $this->bind(AntiCsrfInterface::class)->to(AntiCsrf::class)->in(Scope::SINGLETON);
+        $this->bind(FailureHandlerInterface::class)->to(OnFailureMethodHandler::class);
+        $this->bind(FailureHandlerInterface::class)
+            ->annotatedWith('vnd_error')->to(VndErrorHandler::class)->in(Scope::SINGLETON);
+        $this->bind(HelperLocatorFactory::class);
+        $this->bind(FilterFactory::class);
+        $this->bindInterceptor(
+            $this->matcher->any(),
+            $this->matcher->annotatedWith(InputValidation::class),
+            [InputValidationInterceptor::class],
+        );
+        $this->bindInterceptor(
+            $this->matcher->any(),
+            $this->matcher->annotatedWith(FormValidation::class),
+            [AuraInputInterceptor::class],
+        );
+    }
+}

--- a/tests/Fake/FakeModule.php
+++ b/tests/Fake/FakeModule.php
@@ -10,7 +10,7 @@ class FakeModule extends AbstractModule
     protected function configure()
     {
         $this->bind(Phpfunc::class)->to(FakePhpFunc::class);
-        $this->install(new AuraInputModule);
+        $this->install(new WebFormModule());
         $this->bind(FormInterface::class)->annotatedWith('contact_form')->to(FakeForm::class);
     }
 }

--- a/tests/WebFormModuleTest.php
+++ b/tests/WebFormModuleTest.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ray\WebFormModule;
+
+use PHPUnit\Framework\TestCase;
+use Ray\Aop\WeavedInterface;
+use Ray\Di\AbstractModule;
+use Ray\Di\Injector;
+use Ray\WebFormModule\Exception\ValidationException;
+
+class WebFormModuleTest extends TestCase
+{
+    public function testWebFormModule()
+    {
+        $injector = new Injector(new class () extends AbstractModule {
+            protected function configure()
+            {
+                $this->install(new WebFormModule());
+                $this->bind(FormInterface::class)->annotatedWith('contact_form')->to(FakeForm::class);
+            }
+        }, __DIR__ . '/tmp');
+        $controller = $injector->getInstance(FakeController::class);
+        $this->assertInstanceOf(WeavedInterface::class, $controller);
+    }
+
+    public function testAuraInputModuleIsAliasOfWebFormModule()
+    {
+        $this->assertInstanceOf(WebFormModule::class, new AuraInputModule());
+    }
+
+    public function testExceptionOnFailure()
+    {
+        $this->expectException(ValidationException::class);
+        $injector = new Injector(new class () extends AbstractModule {
+            protected function configure()
+            {
+                $this->install(new WebFormModule());
+                $this->bind(FormInterface::class)->annotatedWith('contact_form')->to(FakeForm::class);
+            }
+        }, __DIR__ . '/tmp');
+        /** @var FakeInputValidationController $controller */
+        $controller = $injector->getInstance(FakeInputValidationController::class);
+        $controller->createAction('');
+    }
+}


### PR DESCRIPTION
## Summary

Add `Ray\WebFormModule\WebFormModule` whose name lines up with the package (`ray/web-form-module`) and namespace (`Ray\WebFormModule`), so the public module class no longer leaks the underlying Aura.Input implementation detail.

`Ray\WebFormModule\AuraInputModule` is preserved as a thin subclass of `WebFormModule`, so existing applications that install `new AuraInputModule()` continue to work unchanged.

### Changes

- Add `src/WebFormModule.php` (real module class)
- Reduce `src/AuraInputModule.php` to `class AuraInputModule extends WebFormModule {}` with a deprecation note
- Add `tests/WebFormModuleTest.php` to cover the new class and confirm `AuraInputModule` is a subclass of `WebFormModule`
- Keep `tests/AuraInputInterceptorTest.php` using `new AuraInputModule()` to lock in BC
- Update `README.md`, `README.JA.md`, the CSRF demo and the fake test module to install `WebFormModule`
- Add `1.0.1` entry to `CHANGELOG.md`

### Why now

The 1.0.0 release just went out and the historical rename to `AuraInputModule` (commit `85ba5a7`, 2015) left the public class name out of sync with the package and namespace. Doing the rename as 1.0.1 keeps the 1.0.0 tag immutable while shipping the cleanup with full backwards compatibility.

## Test plan

- [x] `composer test` — 32 tests, 36 assertions, all green
- [x] `composer cs` / `composer cs-fix` — clean
- [x] `composer phpstan` — no errors

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced WebFormModule as the primary module for form handling.

* **Deprecation**
  * AuraInputModule marked deprecated and retained as a backwards-compatible alias.

* **Documentation**
  * Updated changelog, README (en/ja) and demo examples to show installing and extending the new module.

* **Tests**
  * Added tests covering the new module, the legacy alias, and validation failure behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ray-di/Ray.WebFormModule/pull/29?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->